### PR TITLE
build: Github actions: Use ninja, upgrade compiler

### DIFF
--- a/.github/workflows/ubuntu-20.04.yml
+++ b/.github/workflows/ubuntu-20.04.yml
@@ -14,22 +14,22 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install compilers
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get update
-        sudo apt-get install -y g++-11
+        sudo apt-get install -y g++-11 ninja-build
         sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-11 90
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-11 90
 
     - name: Configure CMake
       run: |
-        cmake --preset make
+        cmake --preset default
 
     - name: Build
-      run: cmake --build --preset make
+      run: cmake --build --preset default
 
     - name: Test
-      run: ctest --output-on-failure --preset make
+      run: ctest --output-on-failure --preset default

--- a/.github/workflows/ubuntu-22.04.yml
+++ b/.github/workflows/ubuntu-22.04.yml
@@ -14,21 +14,21 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install compilers
       run: |
         sudo apt-get update
-        sudo apt-get install -y g++-12
-        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-12 90
-        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 90
+        sudo apt-get install -y ninja-build
+        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-13 90
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-13 90
 
     - name: Configure CMake
       run: |
-        cmake --preset make
+        cmake --preset default
 
     - name: Build
-      run: cmake --build --preset make
+      run: cmake --build --preset default
 
     - name: Test
-      run: ctest --output-on-failure --preset make
+      run: ctest --output-on-failure --preset default


### PR DESCRIPTION
- Upgrade checkout action
- Use ninja to build
- Upgrade gcc to gcc-13 on Ubuntu 22.04